### PR TITLE
Fix installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from splipy import __version__
+
+# Creates the __version__ name. We can't import it because it will try to load
+# dependencies before they are installed.
+with open('splipy/__version__.py', 'r') as f:
+    exec(f.read())
 
 setup(
     name='Splipy',

--- a/splipy/__init__.py
+++ b/splipy/__init__.py
@@ -6,6 +6,6 @@ from splipy.Curve import Curve
 from splipy.Surface import Surface
 from splipy.Volume import Volume
 from splipy.SplineModel import SplineModel
+from splipy.__version__ import __version__
 
-__version__ = '1.0.0'
-__all__ = ['BSplineBasis', 'SplineObject', 'Curve', 'Surface', 'Volume', 'SplineModel']
+__all__ = ['BSplineBasis', 'SplineObject', 'Curve', 'Surface', 'Volume', 'SplineModel', '__version__']

--- a/splipy/__version__.py
+++ b/splipy/__version__.py
@@ -1,0 +1,4 @@
+# WARNING: This file is executed at packaging time.
+# Don't put nasty things here.
+
+__version__ = '1.0.0'


### PR DESCRIPTION
Currently if you try to install from scratch it needs to import splipy to get the version number, but it can't because the dependencies (scipy, numpy) aren't there yet.
