### PR TITLE
No trailing space

### DIFF
--- a/splipy/IO/g2.py
+++ b/splipy/IO/g2.py
@@ -39,13 +39,11 @@ class G2(MasterIO):
         self.fstream.write('{} {}\n'.format(obj.dimension, int(obj.rational)))
         for b in obj.bases:
             self.fstream.write('%i %i\n' % (len(b.knots) - b.order, b.order))
-            for k in b.knots:
-                self.fstream.write('%f ' % k)
+            self.fstream.write(' '.join('%f' % k for k in b.knots))
             self.fstream.write('\n')
 
         for cp in obj:
-            for x in cp:
-                self.fstream.write('%f ' % x)
+            self.fstream.write(' '.join('%f' % x for x in cp))
             self.fstream.write('\n')
 
     def read(self):


### PR DESCRIPTION
I guess there is no such thing as a G2 standard, but at least Splipy should be able to read its own output. If there's a trailing space, then lines such as `"0.1 0.2 0.3 \n"` will be split on space to yield `["0.1", "0.2", "0.3", "\n"]`, which has an invalid floating point number. With no trailing space we get `["0.1", "0.2", "0.3\n"]`, and `float("0.3\n")` is legal.
