### PR TITLE
Updated to ubuntu 16.04, opencv v.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ This library depends on numpy and scipy. E.g. on Ubuntu::
 
 If you use Python 2, you need OpenCV for the imaging tools to work::
 
-    sudo apt-get install opencv
+    sudo apt-get install python-opencv
 
 To generate the documentation you will need Sphinx::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 column_limit = 100
 dedent_closing_brackets = False
 
-[pytest]
+[tool:pytest]
 python_files = *_test.py
 
 [run]

--- a/splipy/utils/image.py
+++ b/splipy/utils/image.py
@@ -113,12 +113,19 @@ def image_curves(filename):
     imBlack  = np.zeros((len(im),   len(im[0])),   np.uint8)
 
     # convert to greyscale image
-    cv2.cvtColor(im, cv2.cv.CV_RGB2GRAY, imGrey)
+    if cv2.__version__[0] == '2':
+        cv2.cvtColor(im, cv2.cv.CV_RGB2GRAY, imGrey)
+    else:
+        cv2.cvtColor(im, cv2.COLOR_RGB2GRAY, imGrey)
+
     # convert to binary black/white
     cv2.threshold(imGrey, 128, 255, cv2.THRESH_BINARY, imBlack)
 
     # find contour curves in image
-    [contours, hierarchy] = cv2.findContours(imBlack, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
+    if cv2.__version__[0] == '2':
+        [contours, _]    = cv2.findContours(imBlack, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
+    else:
+        [_, contours, _] = cv2.findContours(imBlack, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
 
     result = []
     for i in range(len(contours)-1):   # for all contours (except the last one which is the edge)
@@ -202,7 +209,10 @@ def image_height(filename, N=[30,30], p=[4,4]):
     imGrey = np.zeros((len(im),   len(im[0])),   np.uint8)
 
     # convert to greyscale image
-    cv2.cvtColor(im, cv2.cv.CV_RGB2GRAY, imGrey)
+    if cv2.__version__[0] == '2':
+        cv2.cvtColor(im, cv2.cv.CV_RGB2GRAY, imGrey)
+    else:
+        cv2.cvtColor(im, cv2.COLOR_RGB2GRAY, imGrey)
 
     pts = []
     # guess uniform evaluation points and knot vectors


### PR DESCRIPTION
* OpenCV API changed from version 2 to 3, and we now support both.
* The package opencv seem to have been renamed to python-opencv
* I have no idea why, but my pytest insisted on inserting a `tool` keyword

```
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
```