### PR TITLE
Support evaluation on non-tensor grids

### DIFF
--- a/splipy/Curve.py
+++ b/splipy/Curve.py
@@ -72,7 +72,7 @@ class Curve(SplineObject):
 
         return result
 
-    def derivative(self, t, d=1, above=True):
+    def derivative(self, t, d=1, above=True, tensor=True):
         """derivative(u, [d=1])
 
         Evaluate the derivative of the curve at the given parametric values.
@@ -91,7 +91,7 @@ class Curve(SplineObject):
         :rtype: numpy.array
         """
         if not self.rational or d != 2:
-            return super(Curve, self).derivative(t, d=d, above=above)
+            return super(Curve, self).derivative(t, d=d, above=above, tensor=tensor)
 
         t = ensure_listlike(t)
         dN = self.bases[0].evaluate(t, d, above)

--- a/splipy/volume_test.py
+++ b/splipy/volume_test.py
@@ -43,6 +43,22 @@ class TestVolume(unittest.TestCase):
         with self.assertRaises(ValueError):
             val = vol(.5, .2, -10)  # evalaute outside parametric domain
 
+    def test_evaluate_nontensor(self):
+        vol = Volume(BSplineBasis(7), BSplineBasis(7), BSplineBasis(5))
+
+        u_val = [0, 0.1, 0.9, 0.3]
+        v_val = [0.2, 0.3, 0.9, 0.4]
+        w_val = [0.3, 0.5, 0.5, 0.0]
+        value = vol(u_val, v_val, w_val, tensor=False)
+
+        self.assertEqual(value.shape[0], 4)
+        self.assertEqual(value.shape[1], 3)
+
+        for i, (u, v, w) in enumerate(zip(u_val, v_val, w_val)):
+            self.assertAlmostEqual(value[i, 0], u)  # identity map x=u
+            self.assertAlmostEqual(value[i, 1], v)  # identity map y=v
+            self.assertAlmostEqual(value[i, 2], w)  # identity map z=w
+
     def test_indexing(self):
         v = Volume()
 


### PR DESCRIPTION
Say you have a unit square and want to evaluate it at two arbitrary points. The current evaluation method doesn't let you do that easily, it only works on tensor product grids. This adds an optional argument `tensor` to evaluation functions that enables the alternative behaviour.

e.g.

```python
import splipy.surface_factory as sf
s = sf.square()
s.evaluate([0, 1], [0, 1])  # => 2 × 2 × 2 array
s.evaluate([0, 1], [0, 1], tensor=False)  # => [[0,0], [1,1]], 2 × 2 array
```