### PR TITLE
Add config for bumpversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,32 @@ To run the tests, you can use your favourite test runner. For example, with
 pytest::
 
     py.test splipy test_utils
+
+
+Releasing
+---------
+
+To make a new release, it is recommended to install `bumpversion
+<https://pypi.python.org/pypi/bumpversion>`_. To make a new release, run::
+
+    bumpversion <type>
+
+where `type` is one of `patch`, `minor` or `major`. This will up the version
+number, create a commit and a tag. To push this to github, use::
+
+    git push --tags
+
+After that, to create the actual packages, run::
+
+    rm -rf dist
+    python setup.py sdist
+    python setup.py bdist_wheel --universal
+
+to create a source distribution and a wheel. These can then be uploaded where
+they need to be uploaded. The recommended way to do that is using `twine
+<https://pypi.python.org/pypi/twine>`_::
+
+    twine upload dist/* -r <index>
+
+Where `index` is the name of the index in your `~/.pypirc` where you want to
+upload.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,11 @@ python_files = *_test.py
 
 [run]
 omit = *_test.py
+
+[bumpversion]
+current_version = 1.0.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+[bumpversion:file:splipy/__init__.py]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from splipy import __version__
 
 setup(
     name='Splipy',
-    version=__version__,
+    version='1.0.0',
     description='Spline modelling library for Python',
     maintainer='Arne Morten Kvarving',
     maintainer_email='arne.morten.kvarving@sintef.no',


### PR DESCRIPTION
I read the Python packaging guidelines today and our current solution for this isn't good (or even correct, strictly speaking).

https://pypi.python.org/pypi/bumpversion

With this, you can now just do `bumpversion patch`, `bumpversion minor`, etc.