### PR TITLE
Add a handy reshape utility function

### DIFF
--- a/splipy/SplineObject.py
+++ b/splipy/SplineObject.py
@@ -84,14 +84,9 @@ class SplineObject(object):
         self.rational = rational
 
         if not raw:
-            # Reshape the array so that it's not just flat
-            cp_shape = tuple([b.num_functions() for b in bases[::-1]] + [self.dimension + rational])
-            self.controlpoints = np.reshape(self.controlpoints, cp_shape)
-
-            # Compensate for numpy's row-major ordering
-            # cps = cps.transpose((n-1,n-2,...,0,n))
-            spec = tuple(list(range(len(bases)))[::-1] + [len(bases)])
-            self.controlpoints = self.controlpoints.transpose(spec)
+            shape = tuple(b.num_functions() for b in bases)
+            ncomps = self.dimension + rational
+            self.controlpoints = reshape(self.controlpoints, shape, order='F', ncomps=ncomps)
 
     def _validate_domain(self, *params):
         """Check whether the given evaluation parameters are valid.

--- a/splipy/utils/__init__.py
+++ b/splipy/utils/__init__.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division
 from itertools import combinations, product
 from math import atan2, sqrt
+import numpy as np
 
 try:
     from collections.abc import Sized
@@ -104,3 +106,32 @@ def flip_and_move_plane_geometry(obj, center=(0,0,0), normal=(0,0,1)):
     if center != (0,0,0):
         obj.translate(center)
     return obj
+
+def reshape(cps, newshape, order='C', ncomps=None):
+    """Like numpy's reshape, but preserves control points of several dimensions
+    that are stored contiguously.
+
+    The return value has shape (*newshape, ncomps), where ncomps is the number
+    of components per control point, as inferred by the size of `cps` and the
+    desired shape.
+
+    The `order` argument ('C' or 'F') determines the order in which control
+    points are read, but does *not* affect the order in which each component of
+    a control point is read.
+    """
+    npts = np.prod(newshape)
+    if ncomps is None:
+        try:
+            ncomps = cps.size // npts
+        except AttributeError:
+            ncomps = len(cps) // npts
+
+    if order == 'C':
+        shape = list(newshape) + [ncomps]
+    elif order == 'F':
+        shape = list(newshape[::-1]) + [ncomps]
+    cps = np.reshape(cps, shape)
+    if order == 'F':
+        spec = list(range(len(newshape)))[::-1] + [len(newshape)]
+        cps = cps.transpose(spec)
+    return cps


### PR DESCRIPTION
I don't know if the docstring explains this well, but basically since IFEM outputs control points in Fortran order for each parameter direction, but still has each control point component stored contiguously, it requires some transpose/reshape shenanigans each time you want to create a Splipy cp array (which is fully C order all the way). Therefore I created this reshape function, which is more or less like numpy's reshape function (has an `order` argument that can be `C` or `F`), but which has an “invisible” extra dimension for components.

IOW,

    # From IFEM, 3 in x direction and 2 in y direction
    cps = [1,2,3,4,5,6,7,8,9,10,11,12]

    cps = splipy.util.reshape(cps, (3,2), order='F')
    # => (1,2) ( 7, 8)
    #    (3,4) ( 9,10)
    #    (5,6) (11,12)
    # as expected