### PR TITLE
Fix: volume_factory.revolve now supports non-full circle revolution

### DIFF
--- a/splipy/factory_test.py
+++ b/splipy/factory_test.py
@@ -733,7 +733,22 @@ class TestVolumeFactory(unittest.TestCase):
         self.assertEqual(np.allclose(R, U+1), True)
         self.assertEqual(np.allclose(x[:,:,:,2], V), True)
         self.assertAlmostEqual(vol.volume(), 2*pi*1.5, places=3)
-    
+
+        # test incomplete reolve
+        vol = VolumeFactory.revolve(square, theta=pi/3)
+        vol.reparam()  # set parametric space to (0,1)^3
+        u = np.linspace(0, 1, 7)
+        v = np.linspace(0, 1, 7)
+        w = np.linspace(0, 1, 7)
+        x = vol.evaluate(u,v,w)
+        V,U,W = np.meshgrid(v,u,w)
+        R = np.sqrt(x[:,:,:,0]**2 + x[:,:,:,1]**2)
+
+        self.assertEqual(np.allclose(R, U+1), True)
+        self.assertEqual(np.allclose(x[:,:,:,2], V), True)
+        self.assertAlmostEqual(vol.volume(), 2*pi*1.5/6, places=3)
+        self.assertTrue(np.all(x >= 0)) # completely contained in first octant
+
     def test_interpolate(self):
         t = np.linspace(0, 1, 5)
         V,U,W = np.meshgrid(t,t,t)

--- a/splipy/volume_factory.py
+++ b/splipy/volume_factory.py
@@ -118,22 +118,19 @@ def revolve(surf, theta=2 * pi):
     surf.set_dimension(3)  # add z-components (if not already present)
     surf.force_rational()  # add weight (if not already present)
     n = len(surf)  # number of control points of the surface
-    cp = np.zeros((8 * n, 4))
-    basis = BSplineBasis(3, [-1, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5], periodic=0)
-    basis *= 2 * pi / 4  # set parametric domain to (0,2pi) in w-direction
+    path = CurveFactory.circle_segment(theta=theta)
+    m = len(path)
 
-    # loop around the circle and set control points by the traditional 9-point
-    # circle curve with weights 1/sqrt(2), only here C0-periodic, so 8 points
-    for i in range(8):
-        if i % 2 == 0:
-            weight = 1.0
-        else:
-            weight = 1.0 / sqrt(2)
+    cp = np.zeros((m * n, 4))
+
+    dt = (path.knots(0)[1] - path.knots(0)[0]) / 2.0
+    for i in range(m):
+        weight = path[i,-1]
         cp[i * n:(i + 1) * n, :] = np.reshape(surf.controlpoints.transpose(1, 0, 2), (n, 4))
         cp[i * n:(i + 1) * n, 2] *= weight
         cp[i * n:(i + 1) * n, 3] *= weight
-        surf.rotate(pi / 4)
-    return Volume(surf.bases[0], surf.bases[1], basis, cp, True)
+        surf.rotate(dt)
+    return Volume(surf.bases[0], surf.bases[1], path.bases[0], cp, True)
 
 
 def cylinder(r=1, h=1, center=(0,0,0), axis=(0,0,1)):


### PR DESCRIPTION
Unit test on revolved square:

![square-torus-piece](https://user-images.githubusercontent.com/3500376/31721018-7cbbc9b6-b418-11e7-9b1b-e0566334b6e9.png)
