### PR TITLE
Additional optimization of spline basis evaluation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools import setup
 from Cython.Build import cythonize
+import numpy as np
 
 setup(
     name='Splipy',
@@ -26,6 +27,7 @@ setup(
         'Images':        ["opencv-python>=3.3"],
     },
     ext_modules=cythonize("splipy/basis_eval.pyx"),
+    include_dirs=[np.get_include()],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Topic :: Multimedia :: Graphics :: 3D Modeling',

--- a/splipy/basis_eval.pyx
+++ b/splipy/basis_eval.pyx
@@ -4,62 +4,66 @@ cimport numpy as np
 import copy
 cimport cython
 
-# cdef inline int int_max(int a, int b): return a if a >= b else b
-# cdef inline unsigned int uint_min(unsigned int a, unsigned int b): return a if a <= b else b
-def my_bisect_left(array, value, n):
-    cdef unsigned int n0 = 0
-    cdef unsigned int i
-    while n0+1 < n:
-        i=np.floor((n0+n-1)/2)
-        if array[i] < value:
-            n0 = i+1
-        else:
-            n = i+1
-    return n0
 
-def my_bisect_right(array, value, n):
-    cdef unsigned int n0 = 0
-    cdef unsigned int i
-    while n0+1 < n:
-        i=np.floor((n0+n-1)/2)
-        if array[i] > value:
-            n = i+1
+cdef my_bisect_left(np.float_t[:] array, np.float_t value, unsigned int hi):
+    cdef unsigned int lo = 0
+    cdef unsigned int mid
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if array[mid] < value:
+            lo = mid + 1
         else:
-            n0 = i+1
-    return n0
+            hi = mid
+    return lo
+
+
+cdef my_bisect_right(np.float_t[:] array, np.float_t value, unsigned int hi):
+    cdef unsigned int lo = 0
+    cdef unsigned int mid
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if value < array[mid]:
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo
+
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function
-def evaluate(knots_in, order_in, eval_t_in, periodic_in, tolerance_in, derivatives_in=0, from_right=True):
+def evaluate(np.ndarray[np.float_t, ndim=1] knots_in,
+             unsigned int p,
+             np.ndarray[np.float_t, ndim=1] eval_t_in,
+             int periodic,
+             np.float_t tol,
+             unsigned int d=0,
+             bint from_right=True):
     """  Evaluate all basis functions in a given set of points.
 
     :param knots_in:       Knot vector
-    :param order_in:       Parametrization order (polyonomial degree + 1)
+    :param p:              Parametrization order (polyonomial degree + 1)
     :param eval_t_in:      The parametric coordinate(s) in which to evaluate
-    :param periodic_in:    Periodicity of basis
-    :param tolerance_in:   Knot tolerance for detecting end-point-evaluations
-    :param derivatives_in: Number of derivatives to compute
+    :param periodic:       Periodicity of basis
+    :param tol:            Knot tolerance for detecting end-point-evaluations
+    :param d:              Number of derivatives to compute
     :param from_right:     True if evaluation should be done in the limit from above
     :return: Two tuples of all arguments to the scipy sparse csr_matrix
     """
 
     # wrap everything into c-type datastructures for optimized performence
-    cdef np.ndarray knots   = knots_in
-    cdef int periodic       = periodic_in
-    cdef unsigned int p     = order_in  # knot vector order
-    cdef unsigned int n_all = len(knots) - p  # number of basis functions (without periodicity)
-    cdef unsigned int n     = len(knots) - p - (periodic+1)  # number of basis functions (with periodicity)
-    cdef unsigned int m     = len(eval_t_in)
-    cdef unsigned int d     = derivatives_in
-    cdef double start       = knots[p-1]
-    cdef double end         = knots[n_all]
-    cdef double evalT       ;
-    cdef double tol         = tolerance_in
-    cdef unsigned int mu    = 0
-    cdef double[:] t        = copy.deepcopy(eval_t_in)
-    cdef double[:] data     = np.zeros(m*p)
-    cdef int[:]    indices  = np.zeros(m*p, dtype='int32')
-    cdef int[:]    indptr   = np.arange(0,m*p+1,p, dtype='int32')
-    cdef double[:] M        = np.zeros(p)  # temp storage to keep all the function evaluations
+    cdef np.float_t[:] knots = knots_in
+    cdef unsigned int n_all  = len(knots) - p  # number of basis functions (without periodicity)
+    cdef unsigned int n      = len(knots) - p - (periodic+1)  # number of basis functions (with periodicity)
+    cdef unsigned int m      = len(eval_t_in)
+    cdef np.float_t start    = knots[p-1]
+    cdef np.float_t end      = knots[n_all]
+    cdef np.float_t evalT
+    cdef unsigned int mu     = 0
+
+    cdef np.float_t[:] t    = eval_t_in.copy()
+    cdef np.float_t[:] data = np.zeros(m*p, dtype=np.float)
+    cdef np.int32_t[:] indices  = np.zeros(m*p, dtype=np.int32)
+    cdef np.int32_t[:] indptr   = np.arange(0,m*p+1,p, dtype=np.int32)
+    cdef np.float_t[:] M        = np.zeros(p, dtype=np.float)  # temp storage to keep all the function evaluations
     cdef unsigned int k,q,j,i
     cdef bint right
 
@@ -80,11 +84,9 @@ def evaluate(knots_in, order_in, eval_t_in, periodic_in, tolerance_in, derivativ
 
         # mu = index of last non-zero basis function
         if right:
-            # mu = my_bisect_right(knots, evalT, n_all+p)
-            mu = bisect_right(knots, evalT)
+            mu = my_bisect_right(knots, evalT, n_all+p)
         else:
-            # mu = my_bisect_left(knots, evalT, n_all+p)
-            mu = bisect_left(knots, evalT)
+            mu = my_bisect_left(knots, evalT, n_all+p)
         mu = min(mu, n_all)
 
         for k in range(p-1):
@@ -93,22 +95,22 @@ def evaluate(knots_in, order_in, eval_t_in, periodic_in, tolerance_in, derivativ
         for q in range(1, p-d):
             j = p-q-1
             k = mu - q -1
-            M[j] = M[j] + M[j + 1] * <double>(knots[k + q + 1] - evalT) / (knots[k + q + 1] - knots[k + 1])
+            M[j] = M[j] + M[j + 1] * (knots[k + q + 1] - evalT) / (knots[k + q + 1] - knots[k + 1])
             for j in range(p - q , p-1):
                 k = mu - p + j  # 'i'-index in global knot vector (ref Hughes book pg.21)
-                M[j] = M[j] * <double>(evalT - knots[k]) / (knots[k + q] - knots[k])
-                M[j] = M[j] + M[j + 1] * <double>(knots[k + q + 1] - evalT) / (knots[k + q + 1] - knots[k + 1])
+                M[j] = M[j] * (evalT - knots[k]) / (knots[k + q] - knots[k])
+                M[j] = M[j] + M[j + 1] * (knots[k + q + 1] - evalT) / (knots[k + q + 1] - knots[k + 1])
             j = p  - 1
             k = mu - 1
-            M[j] = M[j] * <double>(evalT - knots[k]) / (knots[k + q] - knots[k])
+            M[j] = M[j] * (evalT - knots[k]) / (knots[k + q] - knots[k])
 
         for q in range(p-d, p):
             for j in range(p - q - 1, p):
                 k = mu - p + j  # 'i'-index in global knot vector (ref Hughes book pg.21)
                 if j != p-q-1:
-                    M[j] = M[j] * <double>(q) / (knots[k + q] - knots[k])
+                    M[j] = M[j] * q / (knots[k + q] - knots[k])
                 if j != p-1:
-                    M[j] = M[j] - M[j + 1] * <double>(q) / (knots[k + q + 1] - knots[k + 1])
+                    M[j] = M[j] - M[j + 1] * q / (knots[k + q + 1] - knots[k + 1])
 
 
         for j,k in enumerate(range(i*p, (i+1)*p)):
@@ -118,28 +120,26 @@ def evaluate(knots_in, order_in, eval_t_in, periodic_in, tolerance_in, derivativ
 
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function
-def snap(knots_in, eval_t_in, tolerance_in):
+def snap(np.ndarray[np.float_t, ndim=1] knots_in,
+         np.ndarray[np.float_t, ndim=1] eval_t_in,
+         np.float_t tolerance):
     """  Snap evaluation points to knots if they are sufficiently close
-    as given in by state.state.knot_tolerance. This will modify the input vector t
-    :param knots:        Knot vector
+    as given in by state.state.knot_tolerance. This will modify the
+    input vector eval_t_in.
+
+    :param knots_in:     Knot vector
     :param eval_t_in:    The parametric coordinate(s) in which to evaluate
     :param tolerance_in: Knot tolerance for detecting end-point-evaluations
-    :param derivatives_in: Number of derivatives to compute
-
-    :param t: evaluation points
-    :type  t: [float]
-    :return: none
     """
     # wrap everything into c-type datastructures for optimized performence
     cdef unsigned int i,j
-    cdef unsigned int n     = len(knots_in)
-    cdef double       tol   = tolerance_in
-    cdef double[:]    t     = eval_t_in
-    cdef double[:]    knots = knots_in
+    cdef unsigned int  n     = len(knots_in)
+    cdef np.float_t[:] t     = eval_t_in
+    cdef np.float_t[:] knots = knots_in
     for j in range(len(t)):
-        i = bisect_left(knots, t[j])
-        if i < n and abs(knots[i]-t[j]) < tol:
+        i = my_bisect_left(knots, t[j], n)
+        if i < n and abs(knots[i]-t[j]) < tolerance:
             t[j] = knots[i]
-        elif i > 0 and abs(knots[i-1]-t[j]) < tol:
+        elif i > 0 and abs(knots[i-1]-t[j]) < tolerance:
             t[j] = knots[i-1]
 

--- a/splipy/bench_evaluation_test.py
+++ b/splipy/bench_evaluation_test.py
@@ -23,22 +23,22 @@ def evaluate_sparse(basis, nviz):
 n = 100
 p = 4
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-basis")
 def test_evaluate_old(benchmark):
     basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
     benchmark(evaluate_old, basis, 1000)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-basis")
 def test_evaluate_cython(benchmark):
     basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
     benchmark(evaluate_cython, basis, 1000)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-basis")
 def test_evaluate_dense(benchmark):
     basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
     benchmark(evaluate_dense, basis, 1000)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-basis")
 def test_evaluate_sparse(benchmark):
     basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
     benchmark(evaluate_sparse, basis, 1000)

--- a/splipy/benchmark_test.py
+++ b/splipy/benchmark_test.py
@@ -99,32 +99,32 @@ def test_move_operator(benchmark):
 
 
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-splineobject")
 def test_eval(benchmark):
     spline = get_spline('volume', 30, 3)
     benchmark(grid_evaluate, spline, 15)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-splineobject")
 def test_eval_rational(benchmark):
     spline = get_spline('volume', 30, 3, True)
     benchmark(grid_evaluate, spline, 15)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-splineobject")
 def test_deriv(benchmark):
     spline = get_spline('volume', 30, 3)
     benchmark(derivative_evaluate, spline, 15)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-splineobject")
 def test_deriv_rational(benchmark):
     spline = get_spline('volume', 30, 3, True)
     benchmark(derivative_evaluate, spline, 15)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-splineobject")
 def test_tangent(benchmark):
     spline = get_spline('volume', 30, 3)
     benchmark(tangent_evaluate, spline, 15)
 
-@pytest.mark.benchmark(group="evaluate")
+@pytest.mark.benchmark(group="evaluate-splineobject")
 def test_tangent_rational(benchmark):
     spline = get_spline('volume', 30, 3, True)
     benchmark(tangent_evaluate, spline, 15)


### PR DESCRIPTION
First, give types of all input arguments. This probably doesn't matter much for speed since they must be checked anyway. I used `np.float_t` for all doubles. This type is usually anyway the same as `double`, but it might help out on platforms where that't not the case, if any. After everything was typed as a memoryview, I got an 8x speedup (4x before this PR). Implementing bisection in C brought that up to 15x, and doing the same with `snap()` landed us on a not inconsiderable 100x performance improvement!

![screenshot from 2018-03-14 11-28-07](https://user-images.githubusercontent.com/619375/37397030-e14522b2-277a-11e8-9784-b49b652a6225.png)
