### PR TITLE
Fix "from splipy.utils import *" import

### DIFF
--- a/splipy/utils/__init__.py
+++ b/splipy/utils/__init__.py
@@ -158,10 +158,10 @@ def reshape(cps, newshape, order='C', ncomps=None):
         cps = cps.transpose(spec)
     return cps
 
-__all__ = ['nutils',
-           'refinement',
-           'image',
-           'NACA',
-           'curve',
-           'smooth']
-
+__all__ = [
+    'nutils', 'refinement', 'image', 'NACA', 'curve', 'smooth',
+    'rotation_matrix', 'sections', 'section_from_index', 'section_to_index',
+    'check_section', 'check_direction', 'ensure_flatlist', 'is_singleton',
+    'ensure_listlike', 'rotate_local_x_axis', 'flip_and_move_plane_geometry',
+    'reshape',
+]


### PR DESCRIPTION
`from splipy.utils import *` only pulled in the sub-modules, not any of the functions actually defined in `splipy.utils`.