### PR TITLE
STL file object close is missing

### DIFF
--- a/splipy/io/stl.py
+++ b/splipy/io/stl.py
@@ -161,4 +161,5 @@ class STL(MasterIO):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.writer.close()
+        self.writer.fp.close()
 


### PR DESCRIPTION
```close()``` is not called to the STL file object.