### PR TITLE
Fast cython evaluation for massive speedup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
-# import numpy as np
+from Cython.Build import cythonize
+import numpy as np
 
 with open('PyPI_text.md') as f:
     long_description = f.read()
@@ -29,7 +30,8 @@ setup(
         'FiniteElement': ["nutils>=4.0"],
         'Images':        ["opencv-python>=4.0"],
     },
-    # include_dirs=[np.get_include()],
+    ext_modules=cythonize("splipy/basis_eval.pyx"),
+    include_dirs=[np.get_include()],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Topic :: Multimedia :: Graphics :: 3D Modeling',

--- a/splipy/BSplineBasis.py
+++ b/splipy/BSplineBasis.py
@@ -5,6 +5,7 @@ import splipy.state as state
 from bisect import bisect_right, bisect_left
 import numpy as np
 import copy
+from splipy import basis_eval
 from scipy.sparse import csr_matrix
 
 __all__ = ['BSplineBasis']
@@ -106,6 +107,34 @@ class BSplineBasis:
 
     def evaluate(self, t, d=0, from_right=True, sparse=False):
         """  Evaluate all basis functions in a given set of points.
+
+        :param t: The parametric coordinate(s) in which to evaluate
+        :type t: float or [float]
+        :param int d: Number of derivatives to compute
+        :param bool from_right: True if evaluation should be done in the limit
+            from above
+        :param bool sparse: True if computed matrix should be returned as sparse
+        :return: A matrix *N[i,j]* of all basis functions *j* evaluated in all
+            points *i*
+        :rtype: numpy.array
+        """
+        # for single-value input, wrap it into a list so it don't crash on the loop below
+        t = ensure_listlike(t)
+        t = np.array(t, dtype=np.float64)
+        basis_eval.snap(self.knots, t, state.knot_tolerance)
+
+        if self.order <= d: # requesting more derivatives than polymoial degree: return all zeros
+            return np.matrix(np.zeros((len(t), self.num_functions())))
+
+        (data, size) = basis_eval.evaluate(self.knots, self.order, t, self.periodic, state.knot_tolerance, d, from_right)
+
+        N = csr_matrix(data, size)
+        if not sparse:
+            N = N.todense()
+        return N
+
+    def evaluate_old(self, t, d=0, from_right=True, sparse=False):
+        """  Evaluate all basis functions in a given set of points.
         :param t: The parametric coordinate(s) in which to evaluate
         :type t: float or [float]
         :param int d: Number of derivatives to compute
@@ -135,8 +164,6 @@ class BSplineBasis:
             for i in range(len(t)):
                 if t[i] < self.start() or t[i] > self.end():
                     t[i] = (t[i] - self.start()) % (self.end() - self.start()) + self.start()
-                if abs(t[i] - self.start()) < state.knot_tolerance and not from_right:
-                    t[i] = self.end()
         for i in range(len(t)):
             right = from_right
             evalT = t[i]
@@ -144,7 +171,7 @@ class BSplineBasis:
             if abs(t[i] - self.end()) < state.knot_tolerance:
                 right = False
             # Skip non-periodic evaluation points outside the domain
-            if t[i] < self.start() or t[i] > self.end() or (abs(t[i]-self.start()) < state.knot_tolerance and not right):
+            if t[i] < self.start() or t[i] > self.end():
                 continue
 
             # mu = index of last non-zero basis function

--- a/splipy/basis_eval.pyx
+++ b/splipy/basis_eval.pyx
@@ -1,0 +1,147 @@
+from bisect import bisect_right, bisect_left
+import numpy as np
+cimport numpy as np
+import copy
+cimport cython
+
+
+cdef my_bisect_left(np.float_t[:] array, np.float_t value, unsigned int hi):
+    cdef unsigned int lo = 0
+    cdef unsigned int mid
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if array[mid] < value:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+cdef my_bisect_right(np.float_t[:] array, np.float_t value, unsigned int hi):
+    cdef unsigned int lo = 0
+    cdef unsigned int mid
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if value < array[mid]:
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo
+
+
+@cython.boundscheck(False) # turn off bounds-checking for entire function
+def evaluate(np.ndarray[np.float_t, ndim=1] knots_in,
+             unsigned int p,
+             np.ndarray[np.float_t, ndim=1] eval_t_in,
+             int periodic,
+             np.float_t tol,
+             unsigned int d=0,
+             bint from_right=True):
+    """  Evaluate all basis functions in a given set of points.
+
+    :param knots_in:       Knot vector
+    :param p:              Parametrization order (polyonomial degree + 1)
+    :param eval_t_in:      The parametric coordinate(s) in which to evaluate
+    :param periodic:       Periodicity of basis
+    :param tol:            Knot tolerance for detecting end-point-evaluations
+    :param d:              Number of derivatives to compute
+    :param from_right:     True if evaluation should be done in the limit from above
+    :return: Two tuples of all arguments to the scipy sparse csr_matrix
+    """
+
+    # wrap everything into c-type datastructures for optimized performance
+    cdef np.float_t[:] knots = knots_in
+    cdef unsigned int n_all  = len(knots) - p  # number of basis functions (without periodicity)
+    cdef unsigned int n      = len(knots) - p - (periodic+1)  # number of basis functions (with periodicity)
+    cdef unsigned int m      = len(eval_t_in)
+    cdef np.float_t start    = knots[p-1]
+    cdef np.float_t end      = knots[n_all]
+    cdef np.float_t evalT
+    cdef unsigned int mu     = 0
+
+    cdef np.float_t[:] t    = eval_t_in.copy()
+    cdef np.float_t[:] data = np.zeros(m*p, dtype=np.float)
+    cdef np.int32_t[:] indices  = np.zeros(m*p, dtype=np.int32)
+    cdef np.int32_t[:] indptr   = np.arange(0,m*p+1,p, dtype=np.int32)
+    cdef np.float_t[:] M        = np.zeros(p, dtype=np.float)  # temp storage to keep all the function evaluations
+    cdef unsigned int k,q,j,i
+    cdef bint right
+
+    if periodic >= 0:
+        # Wrap periodic evaluation into domain
+        for i in range(len(t)):
+            if t[i] < start or t[i] > end:
+                t[i] = (t[i] - start) % (end - start) + start
+            if abs(t[i] - start) < tol and not from_right:
+                t[i] = end
+    for i in range(len(t)):
+        right = from_right
+        evalT = t[i]
+        # Special-case the endpoint, so the user doesn't need to
+        if abs(t[i] - end) < tol:
+            right = False
+        # Skip non-periodic evaluation points outside the domain
+        if t[i] < start or t[i] > end or (abs(t[i]-start) < tol and not right):
+            continue
+
+        # mu = index of last non-zero basis function
+        if right:
+            mu = my_bisect_right(knots, evalT, n_all+p)
+        else:
+            mu = my_bisect_left(knots, evalT, n_all+p)
+        mu = min(mu, n_all)
+
+        for k in range(p-1):
+            M[k] = 0
+        M[p-1] = 1  # the last entry is a dummy-zero which is never used
+        for q in range(1, p-d):
+            j = p-q-1
+            k = mu - q -1
+            M[j] = M[j] + M[j + 1] * (knots[k + q + 1] - evalT) / (knots[k + q + 1] - knots[k + 1])
+            for j in range(p - q , p-1):
+                k = mu - p + j  # 'i'-index in global knot vector (ref Hughes book pg.21)
+                M[j] = M[j] * (evalT - knots[k]) / (knots[k + q] - knots[k])
+                M[j] = M[j] + M[j + 1] * (knots[k + q + 1] - evalT) / (knots[k + q + 1] - knots[k + 1])
+            j = p  - 1
+            k = mu - 1
+            M[j] = M[j] * (evalT - knots[k]) / (knots[k + q] - knots[k])
+
+        for q in range(p-d, p):
+            for j in range(p - q - 1, p):
+                k = mu - p + j  # 'i'-index in global knot vector (ref Hughes book pg.21)
+                if j != p-q-1:
+                    M[j] = M[j] * q / (knots[k + q] - knots[k])
+                if j != p-1:
+                    M[j] = M[j] - M[j + 1] * q / (knots[k + q + 1] - knots[k + 1])
+
+
+        for j,k in enumerate(range(i*p, (i+1)*p)):
+            data[k]    = M[j]
+            indices[k] = (mu-p+j) % n
+    return (data, indices, indptr), (m,n)
+
+
+@cython.boundscheck(False) # turn off bounds-checking for entire function
+def snap(np.ndarray[np.float_t, ndim=1] knots_in,
+         np.ndarray[np.float_t, ndim=1] eval_t_in,
+         np.float_t tolerance):
+    """  Snap evaluation points to knots if they are sufficiently close
+    as given in by state.state.knot_tolerance. This will modify the
+    input vector eval_t_in.
+
+    :param knots_in:     Knot vector
+    :param eval_t_in:    The parametric coordinate(s) in which to evaluate
+    :param tolerance_in: Knot tolerance for detecting end-point-evaluations
+    """
+    # wrap everything into c-type datastructures for optimized performance
+    cdef unsigned int i,j
+    cdef unsigned int  n     = len(knots_in)
+    cdef np.float_t[:] t     = eval_t_in
+    cdef np.float_t[:] knots = knots_in
+    for j in range(len(t)):
+        i = my_bisect_left(knots, t[j], n)
+        if i < n and abs(knots[i]-t[j]) < tolerance:
+            t[j] = knots[i]
+        elif i > 0 and abs(knots[i-1]-t[j]) < tolerance:
+            t[j] = knots[i-1]
+

--- a/splipy/bench_evaluation_test.py
+++ b/splipy/bench_evaluation_test.py
@@ -1,0 +1,45 @@
+from splipy import BSplineBasis
+import numpy as np
+import unittest
+import pytest
+
+
+def evaluate_old(basis, nviz):
+    t = np.linspace(0, basis.end(), nviz)
+    basis.evaluate_old(t)
+
+def evaluate_cython(basis, nviz):
+    t = np.linspace(0, basis.end(), nviz)
+    basis.evaluate(t)
+
+def evaluate_dense(basis, nviz):
+    t = np.linspace(0, basis.end(), nviz)
+    basis.evaluate_old(t, sparse=False)
+
+def evaluate_sparse(basis, nviz):
+    t = np.linspace(0, basis.end(), nviz)
+    basis.evaluate_old(t, sparse=True)
+
+n = 100
+p = 4
+
+@pytest.mark.benchmark(group="evaluate-basis")
+def test_evaluate_old(benchmark):
+    basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
+    benchmark(evaluate_old, basis, 1000)
+
+@pytest.mark.benchmark(group="evaluate-basis")
+def test_evaluate_cython(benchmark):
+    basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
+    benchmark(evaluate_cython, basis, 1000)
+
+@pytest.mark.benchmark(group="evaluate-basis")
+def test_evaluate_dense(benchmark):
+    basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
+    benchmark(evaluate_dense, basis, 1000)
+
+@pytest.mark.benchmark(group="evaluate-basis")
+def test_evaluate_sparse(benchmark):
+    basis = BSplineBasis(p, [0]*(p-1) + list(range(n-p+2)) + [n-p+1]*(p-1))
+    benchmark(evaluate_sparse, basis, 1000)
+


### PR DESCRIPTION
# Overview

At the very heart of all evaluation, interpolation and approximation schemes in splipy lies the basis function evaluation contained in `BSplineBasis.evaluate`. In this commit, this function is moved to a compiled language "cython" which greatly increases its speed at the cost of generality.

I'm opening a PR on this for increased visibility, but I do not plan to merge this on trunk anytime soon.

# Limitations

This only works on linux platforms which is why it was never released officially on pip

# Advantages

The speedup of cython evaluation when compared to the old pure python counterpart is a factor 100x as is seen when running benchmarks through pytest:

```
------------------------------------------------------------------------------------- benchmark 'evaluate-basis': 4 tests -------------------------------------------------------------------------------------
Name (time in us)                Min                    Max                   Mean              StdDev                 Median                 IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_evaluate_cython        289.3780 (1.0)         776.7820 (1.0)         297.1322 (1.0)       20.5085 (1.0)         293.4075 (1.0)        3.3030 (1.0)        68;269  3,365.5058 (1.0)        2382           1
test_evaluate_old        28,261.9550 (97.66)    33,605.0990 (43.26)    28,881.6505 (97.20)    937.1762 (45.70)    28,579.8615 (97.41)    494.0110 (149.56)        2;2     34.6241 (0.01)         34           1
test_evaluate_dense      29,232.9840 (101.02)   30,364.6940 (39.09)    29,676.2566 (99.88)    263.6799 (12.86)    29,627.2280 (100.98)   303.4720 (91.88)         9;2     33.6970 (0.01)         33           1
test_evaluate_sparse     29,367.1640 (101.48)   30,472.8860 (39.23)    29,852.1572 (100.47)   246.9262 (12.04)    29,851.6680 (101.74)   310.1035 (93.89)         9;1     33.4984 (0.01)         33           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```