### PR TITLE
Implement SplineStructure superclass of SplineObject

### DIFF
--- a/splipy/basis.py
+++ b/splipy/basis.py
@@ -9,7 +9,7 @@ from scipy.sparse import csr_matrix
 from typing import List, Iterable, Tuple
 
 from .utils import ensure_listlike
-from . import basis_eval, state
+from . import basis_eval, state, transform as trf
 
 __all__ = ['BSplineBasis']
 
@@ -556,3 +556,7 @@ class TensorBasis:
     @property
     def shape(self) -> Tuple[int, ...]:
         return tuple(b.num_functions() for b in self.bases)
+
+    def swap(self, dir1: int, dir2: int) -> trf.Transform:
+        self.bases[dir1], self.bases[dir2] = self.bases[dir2], self.bases[dir1]
+        return trf.SwapTransform(dir1, dir2)

--- a/splipy/basis.py
+++ b/splipy/basis.py
@@ -6,6 +6,8 @@ import copy
 import numpy as np
 from scipy.sparse import csr_matrix
 
+from typing import List, Iterable, Tuple
+
 from .utils import ensure_listlike
 from . import basis_eval, state
 
@@ -527,3 +529,30 @@ class BSplineBasis:
         if self.periodic > -1:
             result += ', C' + str(self.periodic) + '-periodic'
         return result
+
+
+class TensorBasis:
+
+    bases: List[BSplineBasis]
+    rational: bool
+
+    def __init__(self, *bases: BSplineBasis, rational: bool = False):
+        self.bases = list(bases)
+        self.rational = rational
+
+    def __iter__(self) -> Iterable[BSplineBasis]:
+        yield from self.bases
+
+    def __len__(self) -> int:
+        return len(self.bases)
+
+    def __getitem__(self, index: int) -> BSplineBasis:
+        return self.bases[index]
+
+    @property
+    def ndims(self) -> int:
+        return len(self)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return tuple(b.num_functions() for b in self.bases)

--- a/splipy/curve.py
+++ b/splipy/curve.py
@@ -6,7 +6,7 @@ from bisect import bisect_left, bisect_right
 import numpy as np
 import scipy.sparse.linalg as splinalg
 
-from .basis import BSplineBasis
+from .basis import BSplineBasis, TensorBasis
 from .splineobject import SplineObject
 from .utils import ensure_listlike, is_singleton
 
@@ -290,7 +290,7 @@ class Curve(SplineObject):
 
         # solve the interpolation problem
         self.controlpoints = np.array(splinalg.spsolve(N_new, interpolation_pts_x))
-        self.bases = [newBasis]
+        self.basis = TensorBasis(newBasis, rational=self.rational)
 
         return self
 
@@ -344,7 +344,7 @@ class Curve(SplineObject):
         new_controlpoints[n1:, :] = extending_curve.controlpoints[1:, :]
 
         # update basis and controlpoints
-        self.bases = [BSplineBasis(p, new_knot)]
+        self.basis = TensorBasis(BSplineBasis(p, new_knot), rational=self.rational)
         self.controlpoints = new_controlpoints
 
         return self

--- a/splipy/curve.py
+++ b/splipy/curve.py
@@ -52,7 +52,7 @@ class Curve(SplineObject):
         squeeze = is_singleton(params[0])
         params = [ensure_listlike(p) for p in params]
 
-        self._validate_domain(*params)
+        self.basis.validate_domain(*params)
 
         # Evaluate the derivatives of the corresponding bases at the corresponding points
         # and build the result array

--- a/splipy/splineobject.py
+++ b/splipy/splineobject.py
@@ -649,16 +649,9 @@ class SplineObject(object):
         dir1 = check_direction(dir1, self.pardim)
         dir2 = check_direction(dir2, self.pardim)
 
-        # Reorder control points
-        new_directions = list(range(self.pardim + 1))
-        new_directions[dir1] = dir2
-        new_directions[dir2] = dir1
-        self.controlpoints = self.controlpoints.transpose(new_directions)
-
         # Swap knot vectors
-        bases = self.bases
-        bases[dir1], bases[dir2] = bases[dir2], bases[dir1]
-        self.basis = TensorBasis(*bases, rational=self.rational)
+        trf = self.basis.swap(dir1, dir2)
+        self.controlpoints = trf(self.controlpoints)
 
         return self
 

--- a/splipy/splineobject.py
+++ b/splipy/splineobject.py
@@ -112,32 +112,8 @@ class SplineObject(object):
         :return: Geometry coordinates
         :rtype: numpy.array
         """
-        squeeze = all(is_singleton(p) for p in params)
-        params = [ensure_listlike(p) for p in params]
-
-        tensor = kwargs.get('tensor', True)
-        if not tensor and len({len(p) for p in params}) != 1:
-            raise ValueError('Parameters must have same length')
-
-        self.basis.validate_domain(*params)
-
-        # Evaluate the corresponding bases at the corresponding points
-        # and build the result array
-        Ns = [b.evaluate(p) for b, p in zip(self.bases, params)]
-        result = evaluate(Ns, self.controlpoints, tensor)
-
-        # For rational objects, we divide out the weights, which are stored in the
-        # last coordinate
-        if self.rational:
-            for i in range(self.dimension):
-                result[..., i] /= result[..., -1]
-            result = np.delete(result, self.dimension, -1)
-
-        # Squeeze the singleton dimensions if we only have one point
-        if squeeze:
-            result = result.reshape(self.dimension)
-
-        return result
+        evaluator = self.basis.evaluate(*params, **kwargs)
+        return evaluator(self.controlpoints)
 
     def derivative(self, *params, **kwargs):
         """Evaluate the derivative of the object at the given parametric values.

--- a/splipy/transform.py
+++ b/splipy/transform.py
@@ -1,0 +1,50 @@
+from typing import List
+
+import numpy as np
+
+
+class Transform:
+    """Superclass for control point transformations."""
+
+    def __call__(self, cps: np.ndarray) -> np.ndarray:
+        ...
+
+    def __mul__(self, other: 'Transform') -> 'Transform':
+        """Compose transforms in a sequence.
+
+            (trf1 * trf2)(cps) == trf2(trf1(cps))
+        """
+        if not isinstance(other, Transform):
+            return NotImplemented
+        if isinstance(other, ChainedTransform):
+            return ChainedTransform(self, *other.sequence)
+        return ChainedTransform(self, other)
+
+
+class ChainedTransform:
+
+    sequence: List[Transform]
+
+    def __init__(self, *sequence: Transform):
+        self.sequence = list(sequence)
+
+    def __call__(self, cps: np.ndarray) -> np.ndarray:
+        for trf in self.sequence:
+            cps = trf(cps)
+        return cps
+
+
+class SwapTransform:
+
+    dir1: int
+    dir2: int
+
+    def __init__(self, dir1: int, dir2: int):
+        self.dir1 = dir1
+        self.dir2 = dir2
+
+    def __call__(self, cps: np.ndarray) -> np.ndarray:
+        new_directions = list(range(cps.ndim))
+        new_directions[self.dir1] = self.dir2
+        new_directions[self.dir2] = self.dir1
+        return cps.transpose(new_directions)


### PR DESCRIPTION
One of the design choices made in nutils is that it makes sense to separate topology and data as much as possible. It's a point of view that I find I'm increasingly sympathetic to, and I find it sometimes quite annoying that in Splipy I'm forced to always have a control point array for each SplineObject even when what I'm really doing is having a spline 'structure' (that is, a set of bases) and a number of fields defined on that structure (that is, control point arrays).

I'd like to be able to use Splipy in this way. If it won't be the officially sanctioned usage pattern then I'd at least like it to be possible.

As a first step, this PR creates a superclass of SplineObject called SplineStructure, which has everything that a SplineObject has minus a control point array. I moved most of the methods that were possible to define only in terms of bases to the super class. Some other methods for operations that work on both the bases and the control points, I've implemented as a superclass method that can be called from the subclass.

These operations also make sense to move either wholly or partially to the superclass, but I've left them alone for now: `lower_periodic`, `split`, `make_periodic` and `make_splines_identical`.

In the future I would like to take this one step further: most of these methods should be defined on the SplineStructure superclass, and they should return objects of some new type `ControlPointOperation` or something like that, which can be applied to the control point arrays. Then the SplineObject class can do stuff like:

```python
def make_periodic(self, *args, **kwargs):
    operation = super().make_periodic(*args, **kwargs)
    self.controlpoints = operation(self.controlpoints)
```

and in my own code I can do stuff like

```python
operation = structure.make_periodic(*args, **kwargs)
fields = [operation(field) for field in fields]
```