### PR TITLE
Travis: remove py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - TWINE_USERNAME=__token__
     # TWINE_PASSWORD should be set to an API token in the Travis settings
   jobs:
-    - CONDA_PYTHON=3.5
     - CONDA_PYTHON=3.6
     - CONDA_PYTHON=3.7
     - CONDA_PYTHON=3.8


### PR DESCRIPTION
As @kmokstad discovered yesterday, the latest Scipy packages do not support 3.5, which means that we can probably drop the testing on that version, since in any case we depend on Scipy. This is great because the cv2 package for 3.5 is broken, causing the tests to fail on 3.5 anyway, so they weren't telling us anything useful.