### PR TITLE
Curve.curvature: 2d cross product needs an absolute sign

### DIFF
--- a/splipy/Curve.py
+++ b/splipy/Curve.py
@@ -219,10 +219,14 @@ class Curve(SplineObject):
             speed     = np.linalg.norm(v)
         else:                 # multiple evaluation points
             if self.dimension == 2:
-                magnitude = w # for 2D-cases np.cross() outputs scalars
-            else:             # for 3D, it is vectors
+                # for 2D-cases np.cross() outputs scalars
+                # (the z-component of the cross product)
+                magnitude = np.abs(w)
+            else:
+                # for 3D, it is vectors
                 magnitude = np.apply_along_axis(np.linalg.norm, -1, w)
-            speed     = np.apply_along_axis(np.linalg.norm, -1, v)
+
+            speed = np.apply_along_axis(np.linalg.norm, -1, v)
 
         return magnitude / np.power(speed,3)
 


### PR DESCRIPTION
I was a little surprised to see Curve.curvature returning negative values when the documentation defines the curvature as the ratio of two vector magnitures. Looking into it a little bit, it looks like np.cross returns a scalar for 2d input vectors, (as the comments in Curve.curvature said), but because that scalar component is the z-component of the cross product, this can be positive or negative, so we should take the absolute value of this.