### PR TITLE
Utils.smooth() supports periodic geometries and filtering on component

### DIFF
--- a/splipy/SplineObject.py
+++ b/splipy/SplineObject.py
@@ -480,7 +480,7 @@ class SplineObject(object):
             direction.
         :return: self
         """
-        
+
         new_bases = [b.raise_order(r) for b, r in zip(self.bases, raises)]
 
         # Set up an interpolation problem

--- a/splipy/utils/smooth.py
+++ b/splipy/utils/smooth.py
@@ -2,25 +2,45 @@ __doc__ = 'Implementation of various smoothing operations on a per-controlpoint 
 
 from scipy import ndimage
 import numpy as np
-import splipy.curve_factory as cf
+from splipy.utils import check_direction
 
-def smooth(obj):
+def smooth(obj, comp=None):
     """Smooth an object by setting the interior control points to the average of
     itself and all neighbours (e.g. 9 for surfaces, 27 for volumes). The edges
     are kept unchanged, and any rational weights are kept unchanged.
 
     :param obj: The object to smooth
     :type obj: :class:`splipy.SplineObject`
+    :param comp: which component to smooth 0=x-component, 1=y-component, 2=z-component, None=all components
+    :type comp: int or None
     """
     n = obj.shape
+    if comp is not None:
+        comp = check_direction(comp, len(obj))
+
     averaging_mask  = np.ones([3]*len(n)+[1])
     averaging_mask /= averaging_mask.size
 
-    new_controlpoints = ndimage.convolve(obj.controlpoints, averaging_mask)
+    new_controlpoints = ndimage.convolve(obj.controlpoints, averaging_mask, mode='wrap')
 
+    # build up the indexing for the domain 'interior'. This would be
+    # controlpoints[1:-1, 1:-1 ,:]        for non-rational surface
+    # controlpoints[ :  , 1:-1 ,:]        for surfaces which is periodic in 'u'
+    # controlpoints[1:-1, 1:-1 ,:-1]      for rational surfaces
+    # controlpoints[1:-1, 1:-1 , 1:-1, :] for non-rational volumes
+    # controlpoints[ :  ,  :   ,  :  , :] for non-rational volumes which is periodic in all three parametric directions
+    interior = []
+    for pardim in range(len(n)):
+        if obj.periodic(pardim):
+            interior.append(slice(None,None,None))
+        else:
+            interior.append(slice(1,-1,None))
     if obj.rational:
-        interior = tuple([slice(1,-1,None)]*len(n) + [slice(0,-1,None)])
+        interior.append(slice(0,-1,None))
+    elif comp is not None:
+        interior.append(slice(comp,comp+1,None))
     else:
-        interior = tuple([slice(1,-1,None)]*len(n) + [slice(None,None,None)])
+        interior.append(slice(None,None,None))
 
+    interior = tuple(interior)
     obj.controlpoints[interior] =  new_controlpoints[interior]


### PR DESCRIPTION
Better control over the `smooth` function. Basically the example below requires two things: first it needs to support periodic geometries (chord is angle parametrized and periodic in the circular direction) and secondly it needs to only alter the x-component of controlpoints to avoid ever leaving the large chord along the x-axis (that is y^2+z^2 should not ever change which all-component smoothing would do).

## Before
![Screenshot from 2021-03-15 14-10-05](https://user-images.githubusercontent.com/3500376/111158565-73d82380-8598-11eb-8ff7-a51e5490d7da.png)


## After
![Screenshot from 2021-03-15 14-10-27](https://user-images.githubusercontent.com/3500376/111158574-76d31400-8598-11eb-90b8-1fc631c300bd.png)
