### PR TITLE
Make rhino3dm an optional dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ h5py==3.1.0
 tqdm==4.41.1
 nutils==4.1
 rhino3dm==7.6.0
+opencv-python==4.5.2.52

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy==1.5.4
 h5py==3.1.0
 tqdm==4.41.1
 nutils==4.1
+rhino3dm==7.6.0

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ setup(
     install_requires=[
         'numpy    >= 1.15',
         'scipy    >= 1.2',
-        'rhino3dm >= 0.14',
     ],
     extras_require={
         'FiniteElement': ["nutils>=4.0"],
         'Images':        ["opencv-python>=4.0"],
+        'Rhino':         ["rhino3dm>=0.14"],
     },
     # ext_modules=cythonize("splipy/basis_eval.pyx"),
     ext_modules=cythonize([

--- a/splipy/io/__init__.py
+++ b/splipy/io/__init__.py
@@ -13,8 +13,18 @@ except ImportError:
     has_grdecl = False
 
 
+# ThreeDM depends on optional rhino3dm
+try:
+    from .threedm import ThreeDM
+    has_rhino = True
+except ImportError:
+    has_rhino = False
 
-__all__ = ['G2', 'SVG', 'SPL', 'STL', 'OpenFOAM', 'Rhino Ceros']
+
+__all__ = ['G2', 'SVG', 'SPL', 'STL', 'OpenFOAM']
 
 if has_grdecl:
     __all__.append('GRDECL')
+
+if has_rhino:
+    __all__.append('ThreeDM')

--- a/test/io/threedm_test.py
+++ b/test/io/threedm_test.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from splipy.io import ThreeDM
+try:
+    from splipy.io import ThreeDM
+    has_rhino = True
+except ImportError:
+    has_rhino = False
+
 import splipy.curve_factory as CurveFactory
 import splipy.surface_factory as SurfaceFactory
 import numpy as np
@@ -12,6 +17,7 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class Test3DM(unittest.TestCase):
 
+    @unittest.skipIf(not has_rhino, "3DM requires rhino3dm")
     def test_read_unit_curve(self):
         with ThreeDM(THIS_DIR + '/geometries/unit_curve.3dm') as myfile:
             crv = myfile.read()
@@ -22,7 +28,7 @@ class Test3DM(unittest.TestCase):
         self.assertTrue(np.allclose(crv[0], [0,0,0]))
         self.assertTrue(np.allclose(crv[1], [1,0,0]))
 
-
+    @unittest.skipIf(not has_rhino, "3DM requires rhino3dm")
     def test_read_unit_square(self):
         with ThreeDM(THIS_DIR + '/geometries/unit_square.3dm') as myfile:
             srf = myfile.read()
@@ -37,7 +43,7 @@ class Test3DM(unittest.TestCase):
         self.assertTrue(np.allclose(yrange, [0,1]))
         self.assertTrue(np.allclose(zrange, [0,0]))
 
-
+    @unittest.skipIf(not has_rhino, "3DM requires rhino3dm")
     def test_read_unit_cube(self):
         with ThreeDM(THIS_DIR + '/geometries/unit_cube.3dm') as myfile:
             srfs = myfile.read()
@@ -45,7 +51,7 @@ class Test3DM(unittest.TestCase):
         for s in srfs:
             self.assertAlmostEqual(s.area(), 1.0)
 
-
+    @unittest.skipIf(not has_rhino, "3DM requires rhino3dm")
     def test_read_hexagon(self):
         with ThreeDM(THIS_DIR + '/geometries/unit_hexagon.3dm') as myfile:
             crv = myfile.read()
@@ -61,7 +67,7 @@ class Test3DM(unittest.TestCase):
         self.assertTrue(np.allclose(crv[4], [-cos(t),-sin(t),0]))
         self.assertTrue(np.allclose(crv[5], [ cos(t),-sin(t),0]))
 
-
+    @unittest.skipIf(not has_rhino, "3DM requires rhino3dm")
     def test_read_sphere(self):
         with ThreeDM(THIS_DIR + '/geometries/unit_sphere.3dm') as myfile:
             srf = myfile.read()
@@ -71,7 +77,7 @@ class Test3DM(unittest.TestCase):
         self.assertEqual(srf.order(1), 3)
         self.assertAlmostEqual(srf.area(), 4*pi, places=2) # numerical integraion of area accurate to two digits
 
-
+    @unittest.skipIf(not has_rhino, "3DM requires rhino3dm")
     def test_read_torus(self):
         with ThreeDM(THIS_DIR + '/geometries/torus_r1_R3.3dm') as myfile:
             srf = myfile.read()


### PR DESCRIPTION
Also install opencv in the testing suite.

@VikingScientist once this is merged I'd like to make a release, so that we can publish wheels for Python 3.9, which I need to test downstream packages (siso) on 3.9 as well.