### PR TITLE
Force Numpy < 1.20

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -59,7 +59,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
-          CIBW_BEFORE_BUILD: pip install cython numpy
+          CIBW_BEFORE_BUILD: pip install cython numpy<1.20
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'splipy': ['templates/*.bpt'],
     },
     install_requires=[
-        'numpy    >= 1.15',
+        'numpy    >= 1.15, < 1.20',
         'scipy    >= 1.2',
     ],
     extras_require={


### PR DESCRIPTION
I found a problem.

Our wheels are built against 'the latest' Numpy version on any given platform. For most platforms, that's 1.20. Unfortunately, it seems Numpy 1.20 and 1.19 are binary incompatible, so when our wheel is installed alongside Numpy 1.19 we get an error, as seen [here](https://github.com/TheBB/SISO/runs/2780774651?check_suite_focus=true).

I believe the simplest solution for now is to add a version condition on Numpy that excludes 1.20, both when building the wheel and when installing the package.

When we drop support for Python 3.6 (perhaps end of this year, which is when it is end-of-life) we can upgrade the Numpy compatibility, since Numpy doesn't distribute wheels for 3.6 in the newer versions.